### PR TITLE
Docs: refine AGENTS.md SafeExec policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,30 @@ Note: SafeExec is an in-terminal guardrail. If your agent can type into your ter
 
 ## Agent Policy (AGENTS.md)
 
-If you're running an AI agent that can execute commands (including background tasks), add a strict policy like this to your `AGENTS.md`:
+If you're running an AI agent that can execute commands (including background tasks), add a policy like this to your `AGENTS.md`:
 
 ```md
-## SafeExec Policy
-- NEVER type `confirm` or `confirm <token>` for any prompt.
-- If `[SAFEEXEC]` appears (or any command asks for confirmation), STOP and ask the human to confirm manually.
-- NEVER bypass SafeExec:
+## SafeExec Policy (Default)
+- Never type `confirm` or `confirm <token>` automatically.
+- If `[SAFEEXEC]` appears (or any command asks for confirmation), STOP and ask the human to confirm in the foreground terminal.
+- Never use bypasses automatically:
   - Do not set `SAFEEXEC_DISABLED=1`
   - Do not run `safeexec -off` / `safeexec off`
   - Do not call `*.safeexec.real`
   - Do not call absolute-path binaries to evade wrappers (for example: `/bin/rm`, `/usr/bin/rm`, `/usr/bin/git`)
-- NEVER run destructive commands (even if asked):
+  - If you believe a bypass is required, ask first and explain why.
+- For destructive ops, do not execute without explicit approval for the exact command:
   - `rm` with both recursive + force flags (any ordering): `rm -rf`, `rm -fr`, `rm --recursive --force`
   - `git reset`, `git revert`, `git checkout`, `git restore`
   - `git clean -f`, `git switch -f`, `git switch --discard-changes`
   - `git stash drop|clear|pop`
   - `npm/yarn/pnpm/bun audit fix --force` (or `audit --fix --force`)
-- NEVER run the above in background jobs, other panes, or detached tmux sessions.
+- Do not run destructive ops from background jobs, other panes, or detached tmux sessions.
+
+## SafeExec Policy (Strict)
+- Never type `confirm` or `confirm <token>`.
+- Never execute destructive ops; ask the human to run them manually.
+- Never use any bypass mechanism.
 ```
 
 ## Windows Support


### PR DESCRIPTION
Refines the README AGENTS.md snippet to a practical Default vs Strict policy.

Default: agent asks for explicit approval before destructive ops (usable day-to-day).
Strict: agent never executes destructive ops.

AGENTS.md is advisory; this improves compliance but is not a hard security boundary.