### PR TITLE
fix: preserve runtime vars in pkgmgr wrapper template

### DIFF
--- a/safeexec.sh
+++ b/safeexec.sh
@@ -581,24 +581,24 @@ close_tty_pair() {
 }
 
 is_foreground_tty() {
-  if [[ -r "/proc/\\$\\$/stat" ]]; then
+  if [[ -r "/proc/\$\$/stat" ]]; then
     local stat rest state ppid pgrp session tty_nr tpgid
-    stat="\\$(cat "/proc/\\$\\$/stat" 2>/dev/null || true)"
-    [[ -n "\\$stat" ]] || return 0
-    rest="\\${stat#*) }"
-    read -r state ppid pgrp session tty_nr tpgid _ <<<"\\$rest" || return 0
-    [[ -n "\\${pgrp:-}" && -n "\\${tpgid:-}" ]] || return 0
-    [[ "\\$tpgid" == "-1" || "\\$tpgid" == "0" ]] && return 0
-    [[ "\\$pgrp" == "\\$tpgid" ]]
-    return \\$?
+    stat="\$(cat "/proc/\$\$/stat" 2>/dev/null || true)"
+    [[ -n "\$stat" ]] || return 0
+    rest="\${stat#*) }"
+    read -r state ppid pgrp session tty_nr tpgid _ <<<"\$rest" || return 0
+    [[ -n "\${pgrp:-}" && -n "\${tpgid:-}" ]] || return 0
+    [[ "\$tpgid" == "-1" || "\$tpgid" == "0" ]] && return 0
+    [[ "\$pgrp" == "\$tpgid" ]]
+    return \$?
   fi
   return 0
 }
 
 require_foreground_or_die() {
-  local cmd="\\$1"
+  local cmd="\$1"
   if ! is_foreground_tty; then
-    echo "safeexec: BLOCKED (not foreground; refusing confirmation): \\$PM \\$cmd" >&2
+    echo "safeexec: BLOCKED (not foreground; refusing confirmation): \$PM \$cmd" >&2
     exit 126
   fi
 }
@@ -606,17 +606,17 @@ require_foreground_or_die() {
 gen_challenge() {
   local tok=""
   if command -v od >/dev/null 2>&1 && [[ -r /dev/urandom ]]; then
-    tok="\\$(od -An -N3 -tx1 /dev/urandom 2>/dev/null | tr -d ' \\n' | tr '[:lower:]' '[:upper:]')"
+    tok="\$(od -An -N3 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' | tr '[:lower:]' '[:upper:]')"
   fi
-  if [[ -z "\\$tok" ]]; then
+  if [[ -z "\$tok" ]]; then
     local out
-    out="\\$(printf '%s' "\\$\\$:\\$RANDOM:\\$RANDOM:\\$(date +%s 2>/dev/null || echo 0)" | cksum 2>/dev/null || true)"
-    set -- \\$out
-    tok="\\${1:-}"
-    tok="\\${tok:0:6}"
+    out="\$(printf '%s' "\$\$:\$RANDOM:\$RANDOM:\$(date +%s 2>/dev/null || echo 0)" | cksum 2>/dev/null || true)"
+    set -- \$out
+    tok="\${1:-}"
+    tok="\${tok:0:6}"
   fi
-  [[ -n "\\$tok" ]] || tok="000000"
-  printf '%s' "\\$tok"
+  [[ -n "\$tok" ]] || tok="000000"
+  printf '%s' "\$tok"
 }
 
 confirm_or_die() {


### PR DESCRIPTION
## Summary
Fix the package-manager wrapper heredoc escaping so `safeexec.sh install` can generate `npm`/`pnpm`/`bun` wrappers without expanding runtime variables too early.

## Repro
On macOS, running:

```bash
sudo ./safeexec.sh install
```

failed locally with:

```text
./safeexec.sh: line 515: stat: unbound variable
```

Minimal isolated repro without touching host paths:

```bash
source <(sed '$d' safeexec.sh)
SAFEEXEC_ROOT=$(mktemp -d)
SAFEEXEC_DIR="$SAFEEXEC_ROOT/bin"
LOCALBIN="$SAFEEXEC_ROOT/localbin"
SUDOERS_FILE="$SAFEEXEC_ROOT/sudoers"
write_wrapper_pkgmgr npm
```

Before this patch that repro fails in `write_wrapper_pkgmgr npm`.
After this patch it passes and the generated wrapper contains the expected literal runtime variables like `$PM`, `$stat`, and `${...}`.

## Root cause
`write_wrapper_pkgmgr()` uses an unquoted heredoc, so shell expansion happens while generating the wrapper body. A cluster of over-escaped references in the package-manager template caused variables to be expanded at generation time under `set -u` instead of being preserved for wrapper runtime.

## Notes
The neighboring `git` wrapper generator already uses the correct effective escaping pattern. This patch just normalizes the package-manager wrapper block to preserve runtime variables consistently.
